### PR TITLE
Add unit tests for forbidden duck-typing on Amount comparison

### DIFF
--- a/tests/leasingninja/sales/domain/testAmount.py
+++ b/tests/leasingninja/sales/domain/testAmount.py
@@ -40,6 +40,22 @@ class AmountTest(unittest.TestCase):
         # assertThat(areEqual).isTrue();
         self.assertFalse(are_equal)
 
+    def test_givenTwoAmountsWithUnequalClasses_whenEquals_thenAreNotEqual(self):
+        # given
+        class OtherAmount:
+            def __init__(self):
+                self._amount = 100
+                self._currency = "EUR"
+        amount1: Amount = Amount(100, "EUR")
+        amount2: OtherAmount = OtherAmount()
+
+        # when
+        are_equal: bool = amount1 == amount2
+
+        # then
+        # assertThat(areEqual).isTrue();
+        self.assertFalse(are_equal)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Thanks for the nice talk at #OOPMUC.

This PR just adds one more unit test on Value Object Amount demonstrating that duck-typing on comparison is forbidden.